### PR TITLE
Updated core-lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,13 @@ dist: xenial
 language: python
 
 python:
-  - "pypy2.7-6.0.0"
-  # - "pypy2.7-7.0.0"
+  - pypy
 
 install:
-  - travis_retry wget https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.0.0-src.tar.bz2
-  - tar -xjf pypy2.7-v7.0.0-src.tar.bz2
-  - mv pypy2.7-v7.0.0-src pypy
-# command to run tests
+  - travis_retry wget https://downloads.python.org/pypy/pypy2.7-v7.3.1-src.tar.bz2
+  - tar -xjf pypy2.7-v7.3.1-src.tar.bz2
+  - mv pypy2.7-v7.3.1-src pypy
+
 script:
   - PYTHONPATH=$PYTHONPATH:pypy nosetests
   - PYTHONPATH=$PYTHONPATH:pypy ./som.sh -cp Smalltalk TestSuite/TestHarness.som

--- a/tests/basic_interpreter_test.py
+++ b/tests/basic_interpreter_test.py
@@ -29,6 +29,9 @@ class BasicInterpreterTest(unittest.TestCase):
         ("Blocks", "testArg2",  77, Integer),
         ("Blocks", "testArgAndLocal",    8, Integer),
         ("Blocks", "testArgAndContext",  8, Integer),
+        ("Blocks", "testEmptyZeroArg",  1, Integer),
+        ("Blocks", "testEmptyOneArg",  1, Integer),
+        ("Blocks", "testEmptyTwoArg",  1, Integer),
 
         ("Return", "testReturnSelf",           "Return", Class),
         ("Return", "testReturnSelfImplicitly", "Return", Class),
@@ -81,10 +84,12 @@ class BasicInterpreterTest(unittest.TestCase):
 
         ("Regressions", "testSymbolEquality",          1, Integer),
         ("Regressions", "testSymbolReferenceEquality", 1, Integer),
+        ("Regressions", "testUninitializedLocal", 1, Integer),
+        ("Regressions", "testUninitializedLocalInBlock", 1, Integer),
 
         ("BinaryOperation", "test", 3 + 8, Integer),
 
-        ("NumberOfTests", "numberOfTests", 52, Integer),
+        ("NumberOfTests", "numberOfTests", 57, Integer),
     ])
     def test_basic_interpreter_behavior(self, test_class, test_selector,
                                         expected_result, result_type):


### PR DESCRIPTION
This updates the core-lib and adds the basic interpreter tests.
Since PyPy moved, download location and versions are updated, too.

This includes the tests for https://github.com/SOM-st/SOM/pull/54.